### PR TITLE
Process R19 typed records as well

### DIFF
--- a/apps/edts/src/edts_code.erl
+++ b/apps/edts/src/edts_code.erl
@@ -685,7 +685,9 @@ parse_abstract({attribute,_Line,import, {Module, Imports0}}, Acc) ->
              , {arity, A}] || {F, A} <- Imports0],
   orddict:update(imports, fun(I) -> Imports ++ I end, Acc);
 parse_abstract({attribute, Line ,record,{Recordname, Fields}}, Acc) ->
-  FieldsF = fun({record_field, _, {_, _, FName}})        -> FName;
+  FieldsF = fun({typed_record_field, {record_field, _, {_, _, FName}}, _Type}) -> FName;
+               ({typed_record_field, {record_field, _, {_, _, FName}, _Call}, _Type}) -> FName;
+               ({record_field, _, {_, _, FName}})        -> FName;
                ({record_field, _, {_, _, FName}, _Call}) -> FName
             end,
   RecordInfo =

--- a/apps/edts/src/edts_code.erl
+++ b/apps/edts/src/edts_code.erl
@@ -805,7 +805,7 @@ find_rebar3_beam_dir(ErlFilePath) ->
   Clean = cleanpath(ErlFilePath),
   Module = erl_filename_to_module_name(Clean),
   SrcDir = filename:dirname(Clean),
-  Parts = string:split(SrcDir, "/", all),
+  Parts = filename:split(SrcDir),
   Location = find_rebar3_beam_dir_(lists:reverse(Parts), undefined),
   error_logger:error_msg("Guessed at ~p for ~p", [Location, ErlFilePath]),
   Location.


### PR DESCRIPTION
Joe

Thanks for your port to rebar3 - this was the best R19 fork I could find of EDTS.  I've fixed the parsing of typed records to also support R19 syntax and can now jump around function / record definitions with no problem :)